### PR TITLE
Fix signed integer serialization

### DIFF
--- a/src/main.zig
+++ b/src/main.zig
@@ -557,19 +557,19 @@ pub fn Serializer(comptime WriterType: type) type {
                 0...5 => try self.writer.writeByte(negint(value)),
                 5...8 => {
                     try self.writer.writeByte(format(.int_8));
-                    try self.writeIntBig(i8, value);
+                    try self.writer.writeIntBig(i8, value);
                 },
                 8...16 => {
-                    try self.writer.writeByte(format(.uint_16));
-                    try self.writeIntBig(i16, value);
+                    try self.writer.writeByte(format(.int_16));
+                    try self.writer.writeIntBig(i16, value);
                 },
                 16...32 => {
-                    try self.writer.writeByte(format(.uint_32));
-                    try self.writeIntBig(i32, value);
+                    try self.writer.writeByte(format(.int_32));
+                    try self.writer.writeIntBig(i32, value);
                 },
                 32...64 => {
-                    try self.writer.writeByte(format(.uint_64));
-                    try self.writeIntBig(i64, value);
+                    try self.writer.writeByte(format(.int_64));
+                    try self.writer.writeIntBig(i64, value);
                 },
                 else => return error.integerTooBig,
             }

--- a/src/tests.zig
+++ b/src/tests.zig
@@ -31,6 +31,11 @@ test "serialization" {
             .value = 12389567,
             .expected = "\xce\x00\xbd\x0c\xbf",
         },
+        .{
+            .type = i32,
+            .value = -12389567,
+            .expected = "\xd2\xff\x42\xf3\x41",
+        },
     };
 
     inline for (test_cases) |case| {
@@ -52,6 +57,10 @@ test "deserialization" {
         .{
             .type = u32,
             .value = @as(u32, 21049),
+        },
+        .{
+            .type = i64,
+            .value = @as(i64, 9223372036854775807),
         },
         .{
             .type = struct { compact: bool, schema: u7 },


### PR DESCRIPTION
Seems like this code was copy/pasted from unsigned integer serialization code and never tested for correctness. Simple enough fix.