### PR TITLE
Make library build with Zig v0.9.1

### DIFF
--- a/src/main.zig
+++ b/src/main.zig
@@ -252,8 +252,8 @@ pub fn Deserializer(comptime ReaderType: type) type {
                 else => return error.MismatchingFormatType,
             };
 
-            var buffer = try self.allocator.alloc(u8, len);
-            var actual_len = try self.reader.readAll(buffer);
+            const buffer = try self.allocator.alloc(u8, len);
+            const actual_len = try self.reader.readAll(buffer);
 
             if (actual_len < len) return error.EndOfStream;
 
@@ -271,8 +271,8 @@ pub fn Deserializer(comptime ReaderType: type) type {
                 else => return error.MismatchingFormatType,
             };
 
-            var buffer = try self.allocator.alloc(u8, len);
-            var actual_len = try self.reader.readAll(buffer);
+            const buffer = try self.allocator.alloc(u8, len);
+            const actual_len = try self.reader.readAll(buffer);
 
             if (actual_len < len) return error.EndOfStream;
 
@@ -394,8 +394,8 @@ pub fn Deserializer(comptime ReaderType: type) type {
             };
 
             data_type.* = try reader.readIntBig(i8);
-            var buffer = try self.allocator.alloc(u8, len);
-            var actual_len = try reader.readAll(buffer);
+            const buffer = try self.allocator.alloc(u8, len);
+            const actual_len = try reader.readAll(buffer);
 
             if (actual_len < len) return error.EndOfStream;
 
@@ -607,8 +607,7 @@ pub fn Serializer(comptime WriterType: type) type {
             const writer = self.writer;
 
             switch (len) {
-                0...max(u8) => try writer.writeByte(@intCast(u8, len)),
-                max(u8) + 1...max(u8) => {
+                0...max(u8) => {
                     try writer.writeByte(format(.bin_8));
                     try writer.writeByte(@intCast(u8, len));
                 },

--- a/src/main.zig
+++ b/src/main.zig
@@ -253,9 +253,9 @@ pub fn Deserializer(comptime ReaderType: type) type {
             };
 
             var buffer = try self.allocator.alloc(u8, len);
-            var len_read = try self.reader.readAll(buffer);
+            var actual_len = try self.reader.readAll(buffer);
 
-            if (len_read < len) return error.EndOfStream;
+            if (actual_len < len) return error.EndOfStream;
 
             return buffer;
         }
@@ -272,9 +272,9 @@ pub fn Deserializer(comptime ReaderType: type) type {
             };
 
             var buffer = try self.allocator.alloc(u8, len);
-            var len_read = try self.reader.readAll(buffer);
+            var actual_len = try self.reader.readAll(buffer);
 
-            if (len_read < len) return error.EndOfStream;
+            if (actual_len < len) return error.EndOfStream;
 
             return buffer;
         }
@@ -395,7 +395,10 @@ pub fn Deserializer(comptime ReaderType: type) type {
 
             data_type.* = try reader.readIntBig(i8);
             var buffer = try self.allocator.alloc(u8, len);
-            _ = try reader.readAll(buffer);
+            var actual_len = try reader.readAll(buffer);
+
+            if (actual_len < len) return error.EndOfStream;
+
             return buffer;
         }
 

--- a/src/tests.zig
+++ b/src/tests.zig
@@ -2,7 +2,9 @@ const std = @import("std");
 const testing = std.testing;
 const meta = std.meta;
 
-usingnamespace @import("main.zig");
+pub const serializer = @import("./main.zig").serializer;
+pub const deserializer = @import("./main.zig").deserializer;
+pub const Timestamp = @import("./main.zig").Timestamp;
 
 test "serialization" {
     const test_cases = .{
@@ -36,9 +38,9 @@ test "serialization" {
             .value = -12389567,
             .expected = "\xd2\xff\x42\xf3\x41",
         },
-        .{ 
-            .type = f64, 
-            .value = 1.25, 
+        .{
+            .type = f64,
+            .value = 1.25,
             .expected = "\xcb\x3f\xf4\x00\x00\x00\x00\x00\x00",
         },
     };
@@ -112,7 +114,7 @@ test "deserialization" {
 
         var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
         defer arena.deinit();
-        var _deserializer = deserializer(in.reader(), &arena.allocator);
+        var _deserializer = deserializer(in.reader(), arena.allocator());
 
         const result = try _deserializer.deserialize(case.type);
 
@@ -149,7 +151,7 @@ test "(de)serialize timestamp" {
     var in = std.io.fixedBufferStream(&buffer);
     var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
     defer arena.deinit();
-    var _deserializer = deserializer(in.reader(), &arena.allocator);
+    var _deserializer = deserializer(in.reader(), arena.allocator());
 
     const timestamp = Timestamp{ .sec = 50, .nsec = 200 };
     try _serializer.serializeTimestamp(timestamp);
@@ -167,7 +169,7 @@ test "(de)serialize ext format" {
     var in = std.io.fixedBufferStream(&buffer);
     var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
     defer arena.deinit();
-    var _deserializer = deserializer(in.reader(), &arena.allocator);
+    var _deserializer = deserializer(in.reader(), arena.allocator());
 
     try _serializer.serializeExt(2, "Hello world!");
 
@@ -205,7 +207,7 @@ test "(de)serialize with custom declaration" {
     var in = std.io.fixedBufferStream(&buffer);
     var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
     defer arena.deinit();
-    var _deserializer = deserializer(in.reader(), &arena.allocator);
+    var _deserializer = deserializer(in.reader(), arena.allocator());
 
     var decl = Decl{ .x = 10, .y = 50 };
     try _serializer.serialize(decl);

--- a/src/tests.zig
+++ b/src/tests.zig
@@ -161,6 +161,26 @@ test "(de)serialize timestamp" {
     try testing.expectEqual(timestamp, result);
 }
 
+test "(de)serialize bin" {
+    var input = [_]u8{ 0x01, 0x02, 0x08, 0x09 };
+
+    var buffer: [4096]u8 = undefined;
+    var out = std.io.fixedBufferStream(&buffer);
+    var _serializer = serializer(out.writer());
+
+    try _serializer.serialize(@as([]u8, &input));
+
+    var in = std.io.fixedBufferStream(&buffer);
+
+    var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena.deinit();
+    var _deserializer = deserializer(in.reader(), arena.allocator());
+
+    const result = try _deserializer.deserialize([]u8);
+
+    try expectEqualDeep([]u8, &input, result);
+}
+
 test "(de)serialize ext format" {
     var buffer: [4096]u8 = undefined;
     var out = std.io.fixedBufferStream(&buffer);


### PR DESCRIPTION
Changes:
 - Move from the old `*Allocator` pattern to the new `Allocator` one
 - Removed `const` return modifier in `deserializeString`
   - Since the strings were being returned were already being allocated, forcing them to be `const` seemed to me to be an unnecessary constraint forced by the library.
 - Remove unused `BufferTooSmall` (since the move to allocators)
 - Change `compileError` to `@compileError`
 - Fix usages of non-existen `len` variable to the expected `fields_len` variable
 - When using the `readAll` method, if the actual `len` read is less than the expected length, return an error 
   - Otherwise, if a stream ended too early for some reason, whoever was using the deserialized had no way of knowing that part  of the returned buffer data was meaningless
 - Make tests run and pass
![imagem](https://user-images.githubusercontent.com/237442/164915140-150920d4-b759-49a9-8af6-eced8165f097.png)
