### PR TITLE
Prevent Memory Leaks when Deserialization Fails

### DIFF
--- a/src/main.zig
+++ b/src/main.zig
@@ -168,7 +168,7 @@ pub fn Deserializer(comptime ReaderType: type) type {
                     return ptr;
                 },
                 .Slice => try self.deserializeArray(T),
-                .Many => try self.deserializeArray(T),
+                .Many => @compileError("Unsupported pointer type Many"),
                 .C => @compileError("Unsupported pointer type C"),
             };
         }
@@ -533,12 +533,13 @@ pub fn Deserializer(comptime ReaderType: type) type {
                                 self.free(ptr.*);
                                 self.allocator.destroy(ptr.*);
                             },
-                            .Slice, .Many => {
+                            .Slice => {
                                 for (ptr.*) |*v| {
                                     self.free(v);
                                 }
                                 self.allocator.free(ptr.*);
                             },
+                            .Many => @compileError("Unsupported pointer type Many"),
                             .C => @compileError("Unsupported pointer type C"),
                         };
                     },
@@ -794,7 +795,9 @@ pub fn Serializer(comptime WriterType: type) type {
 
             switch (@typeInfo(S).Pointer.size) {
                 .One => try self.serializeTyped(C, value.*),
-                .Many, .C, .Slice => try self.serializeArray(S, value),
+                .Slice => try self.serializeArray(S, value),
+                .Many => @compileError("Unsupported pointer type Many"),
+                .C => @compileError("Unsupported pointer type C"),
             }
         }
 

--- a/src/main.zig
+++ b/src/main.zig
@@ -252,8 +252,8 @@ pub fn Deserializer(comptime ReaderType: type) type {
                 else => return error.MismatchingFormatType,
             };
 
-            var buffer = try self.allocator.alloc(u8, len);
-            var actual_len = try self.reader.readAll(buffer);
+            const buffer = try self.allocator.alloc(u8, len);
+            const actual_len = try self.reader.readAll(buffer);
 
             if (actual_len < len) return error.EndOfStream;
 
@@ -271,8 +271,8 @@ pub fn Deserializer(comptime ReaderType: type) type {
                 else => return error.MismatchingFormatType,
             };
 
-            var buffer = try self.allocator.alloc(u8, len);
-            var actual_len = try self.reader.readAll(buffer);
+            const buffer = try self.allocator.alloc(u8, len);
+            const actual_len = try self.reader.readAll(buffer);
 
             if (actual_len < len) return error.EndOfStream;
 
@@ -394,8 +394,8 @@ pub fn Deserializer(comptime ReaderType: type) type {
             };
 
             data_type.* = try reader.readIntBig(i8);
-            var buffer = try self.allocator.alloc(u8, len);
-            var actual_len = try reader.readAll(buffer);
+            const buffer = try self.allocator.alloc(u8, len);
+            const actual_len = try reader.readAll(buffer);
 
             if (actual_len < len) return error.EndOfStream;
 
@@ -607,8 +607,7 @@ pub fn Serializer(comptime WriterType: type) type {
             const writer = self.writer;
 
             switch (len) {
-                0...max(u8) => try writer.writeByte(@intCast(u8, len)),
-                max(u8) + 1...max(u8) => {
+                0...max(u8) => {
                     try writer.writeByte(format(.bin_8));
                     try writer.writeByte(@intCast(u8, len));
                 },

--- a/src/main.zig
+++ b/src/main.zig
@@ -253,9 +253,9 @@ pub fn Deserializer(comptime ReaderType: type) type {
             };
 
             var buffer = try self.allocator.alloc(u8, len);
-            var len_read = try self.reader.readAll(buffer);
+            var actual_len = try self.reader.readAll(buffer);
 
-            if (len_read < len) return error.EndOfStream;
+            if (actual_len < len) return error.EndOfStream;
 
             return buffer;
         }
@@ -272,9 +272,9 @@ pub fn Deserializer(comptime ReaderType: type) type {
             };
 
             var buffer = try self.allocator.alloc(u8, len);
-            var len_read = try self.reader.readAll(buffer);
+            var actual_len = try self.reader.readAll(buffer);
 
-            if (len_read < len) return error.EndOfStream;
+            if (actual_len < len) return error.EndOfStream;
 
             return buffer;
         }
@@ -395,7 +395,10 @@ pub fn Deserializer(comptime ReaderType: type) type {
 
             data_type.* = try reader.readIntBig(i8);
             var buffer = try self.allocator.alloc(u8, len);
-            _ = try reader.readAll(buffer);
+            var actual_len = try reader.readAll(buffer);
+
+            if (actual_len < len) return error.EndOfStream;
+
             return buffer;
         }
 

--- a/src/main.zig
+++ b/src/main.zig
@@ -220,8 +220,8 @@ pub fn Deserializer(comptime ReaderType: type) type {
             };
             var value: T = undefined;
             // A static array of bits (0 or 1) with the same len as the number of fields on the struct.
-            // If the value of array[i] is 1, it means that array has been set and should be freed in case
-            // of an error or in case the map has duplicate keys
+            // If the value of array[i] is 1, it means that field at position i has been set and should be
+            // freed in case of an error or in case the map has duplicate keys
             var fields_set = [_]u1{0} ** meta.fields(T).len;
             // In case of an early abort of this method, free any fields that had already been set
             errdefer {

--- a/src/main.zig
+++ b/src/main.zig
@@ -145,7 +145,9 @@ pub fn Deserializer(comptime ReaderType: type) type {
         pub fn deserializePointer(self: *Self, comptime T: type) ReadError!T {
             return switch (@typeInfo(T).Pointer.size) {
                 .One => {
-                    var ptr = self.allocator.create(T);
+                    const C = @typeInfo(T).Pointer.child;
+
+                    var ptr: T = try self.allocator.create(C);
                     errdefer self.allocator.destroy(ptr);
                     try self.deserializeInto(ptr);
                     return ptr;
@@ -216,7 +218,9 @@ pub fn Deserializer(comptime ReaderType: type) type {
             }
             var i: usize = 0;
             loop: while (i < len) : (i += 1) {
+                // TODO Study way of using buffer for keys when possible (most often will not be long anyway)
                 const key = try self.deserializeString();
+                defer self.allocator.free(key);
 
                 inline for (meta.fields(T)) |struct_field, field_i| {
                     if (std.mem.eql(u8, struct_field.name, key)) {
@@ -470,7 +474,7 @@ pub fn Deserializer(comptime ReaderType: type) type {
                 },
                 else => switch (@typeInfo(C)) {
                     .Struct => {
-                        inline for (meta.fields(T)) |struct_field| {
+                        inline for (meta.fields(C)) |struct_field| {
                             self.freePartial(&@field(ptr, struct_field.name));
                         }
                     },
@@ -743,8 +747,10 @@ pub fn Serializer(comptime WriterType: type) type {
 
         /// Serializes a pointer and writes its internal value to the `writer`
         pub fn serializePointer(self: *Self, comptime S: type, value: S) WriteError!void {
+            const C = @typeInfo(S).Pointer.child;
+
             switch (@typeInfo(S).Pointer.size) {
-                .One => try self.serializeTyped(S, value),
+                .One => try self.serializeTyped(C, value.*),
                 .Many, .C, .Slice => try self.serializeArray(S, value),
             }
         }

--- a/src/main.zig
+++ b/src/main.zig
@@ -226,7 +226,7 @@ pub fn Deserializer(comptime ReaderType: type) type {
             // In case of an early abort of this method, free any fields that had already been set
             errdefer {
                 inline for (meta.fields(T)) |struct_field, field_i| {
-                    if (fields_set[field_i] == true) {
+                    if (fields_set[field_i]) {
                         self.free(&@field(value, struct_field.name));
                     }
                 }
@@ -247,7 +247,7 @@ pub fn Deserializer(comptime ReaderType: type) type {
                 inline for (meta.fields(T)) |struct_field, field_i| {
                     if (std.mem.eql(u8, struct_field.name, key)) {
                         // If this field was already set, free it's value before overwritting it
-                        if (fields_set[field_i] == true) {
+                        if (fields_set[field_i]) {
                             // Unset the field first, so that if deserializeInto fails later on, we do not need to double-free this field
                             fields_set[field_i] = false;
                             self.free(&@field(value, struct_field.name));

--- a/src/tests.zig
+++ b/src/tests.zig
@@ -2,7 +2,9 @@ const std = @import("std");
 const testing = std.testing;
 const meta = std.meta;
 
-usingnamespace @import("main.zig");
+pub const serializer = @import("./main.zig").serializer;
+pub const deserializer = @import("./main.zig").deserializer;
+pub const Timestamp = @import("./main.zig").Timestamp;
 
 test "serialization" {
     const test_cases = .{
@@ -36,9 +38,9 @@ test "serialization" {
             .value = -12389567,
             .expected = "\xd2\xff\x42\xf3\x41",
         },
-        .{ 
-            .type = f64, 
-            .value = 1.25, 
+        .{
+            .type = f64,
+            .value = 1.25,
             .expected = "\xcb\x3f\xf4\x00\x00\x00\x00\x00\x00",
         },
     };
@@ -112,7 +114,7 @@ test "deserialization" {
 
         var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
         defer arena.deinit();
-        var _deserializer = deserializer(in.reader(), &arena.allocator);
+        var _deserializer = deserializer(in.reader(), arena.allocator());
 
         const result = try _deserializer.deserialize(case.type);
 
@@ -149,7 +151,7 @@ test "(de)serialize timestamp" {
     var in = std.io.fixedBufferStream(&buffer);
     var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
     defer arena.deinit();
-    var _deserializer = deserializer(in.reader(), &arena.allocator);
+    var _deserializer = deserializer(in.reader(), arena.allocator());
 
     const timestamp = Timestamp{ .sec = 50, .nsec = 200 };
     try _serializer.serializeTimestamp(timestamp);
@@ -167,7 +169,7 @@ test "(de)serialize ext format" {
     var in = std.io.fixedBufferStream(&buffer);
     var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
     defer arena.deinit();
-    var _deserializer = deserializer(in.reader(), &arena.allocator);
+    var _deserializer = deserializer(in.reader(), arena.allocator());
 
     try _serializer.serializeExt(2, "Hello world!");
 
@@ -205,7 +207,7 @@ test "(de)serialize with custom declaration" {
     var in = std.io.fixedBufferStream(&buffer);
     var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
     defer arena.deinit();
-    var _deserializer = deserializer(in.reader(), &arena.allocator);
+    var _deserializer = deserializer(in.reader(), arena.allocator());
 
     var decl = Decl{ .x = 10, .y = 50 };
     try _serializer.serialize(decl);

--- a/src/tests.zig
+++ b/src/tests.zig
@@ -279,9 +279,8 @@ test "deserialize no memory leaks" {
     var _serializer = serializer(out.writer());
     try _serializer.serialize(input);
 
+    // Check how much of the buffer was used by the serialization
     const max_size = out.pos;
-
-    _ = allocator;
 
     // Test every possible IO failure scenario and make sure no memory leaks at the end
     var i: usize = 0;
@@ -306,12 +305,13 @@ test "deserialize no memory leaks" {
     var output = try _deserializer.deserialize(TestStruct);
     defer _deserializer.free(&output);
 
-    try testing.expectEqualStrings("foobar", output.str);
-    try testing.expectEqual(@as(usize, 2), output.array.len);
-    try testing.expectEqualStrings("ab", output.array[0].str_1);
-    try testing.expectEqual(@as(f64, 42), output.array[0].float);
-    try testing.expectEqualStrings("cd", output.array[0].str_2);
-    try testing.expectEqualStrings("ef", output.array[1].str_1);
-    try testing.expectEqual(@as(f64, 100), output.array[1].float);
-    try testing.expectEqualStrings("gh", output.array[1].str_2);
+    // Validate the contents of the
+    try testing.expectEqualStrings(input.str, output.str);
+    try testing.expectEqual(input.array.len, output.array.len);
+    try testing.expectEqualStrings(input.array[0].str_1, output.array[0].str_1);
+    try testing.expectEqual(input.array[0].float, output.array[0].float);
+    try testing.expectEqualStrings(input.array[0].str_2, output.array[0].str_2);
+    try testing.expectEqualStrings(input.array[1].str_1, output.array[1].str_1);
+    try testing.expectEqual(input.array[1].float, output.array[1].float);
+    try testing.expectEqualStrings(input.array[1].str_2, output.array[1].str_2);
 }

--- a/src/tests.zig
+++ b/src/tests.zig
@@ -161,6 +161,26 @@ test "(de)serialize timestamp" {
     try testing.expectEqual(timestamp, result);
 }
 
+test "(de)serialize bin" {
+    var input = [_]u8{ 0x01, 0x02, 0x08, 0x09 };
+
+    var buffer: [4096]u8 = undefined;
+    var out = std.io.fixedBufferStream(&buffer);
+    var _serializer = serializer(out.writer());
+
+    try _serializer.serialize(@as([]u8, &input));
+
+    var in = std.io.fixedBufferStream(&buffer);
+
+    var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena.deinit();
+    var _deserializer = deserializer(in.reader(), arena.allocator());
+
+    const result = try _deserializer.deserialize([]u8);
+
+    try expectEqualDeep([]u8, &input, result);
+}
+
 test "(de)serialize ext format" {
     var buffer: [4096]u8 = undefined;
     var out = std.io.fixedBufferStream(&buffer);


### PR DESCRIPTION
Hi again,

This is a sligthly more complex PR, but after my last one I noticed that, ever since allocators began being used in this library, it would leak memory if the reader failed in the middle of a deserialize.

Fixing the most obvious methods was fairly easy (`deserializeString`, `deserializeBin`, etc...) since they allocate memory directly. But it was needed to free memory as well for more complex methods, such as `deserializeArray` and `deserializeStruct`, that can allocate memory indirectly by deserializing their members.

Also the `deserializer.free` method as public to allow easily freeing memory returned by the deserializer. This method has a default behavior, but if the type being passed contains a `deinit` function, it delegates the responsability of freeing the memory to it.

Finally also added a test to test for memory leaks, where I try to deserialize a buffer with len `N` multiple times, failing on different places (first fail on read byte 0, then 1, then 2, etc... until byte `N`). Since we are using the testing allocator, it will fail the tests if any memory leaks are detected during this process (this idea is inspired by the `std.testing.FailingAllocator`, but for failing IO operations instead of allocations.

Looking forward to hear your comments 😃 